### PR TITLE
Include version in title statement of outputs

### DIFF
--- a/build_mei_file.py
+++ b/build_mei_file.py
@@ -5,6 +5,7 @@ import parse_classifier_table as pct
 from pymei import MeiDocument, MeiElement, MeiAttribute, documentToText, documentToFile
 from itertools import groupby
 from visualize_alignment import draw_mei_doc
+from MEI_encoding import __version__
 
 
 def add_flags_to_glyphs(glyphs):
@@ -129,7 +130,7 @@ def generate_base_document():
     fileDesc.addChild(titleSt)
     title = MeiElement('title')
     titleSt.addChild(title)
-    title.setValue('MEI Encoding Output')
+    title.setValue('MEI Encoding Output (%s)' % __version__)
     pubStmt = MeiElement('pubStmt')
     fileDesc.addChild(pubStmt)
 


### PR DESCRIPTION
When issues are found in generated files, this should help determine
which version of MEI_encoding was used to generate it (and if that issue
might have been addressed in a newer version).